### PR TITLE
[Feature] Automatic service discovery

### DIFF
--- a/lm_service/apis/vllm/proxy.py
+++ b/lm_service/apis/vllm/proxy.py
@@ -34,6 +34,7 @@ from lm_service.protocol.protocol import (
     RequestType,
     ResponseType,
     ServerType,
+    WorkerRegisterRequest,
 )
 from lm_service.request_stats import RequestStatsMonitor
 from lm_service.routing_logic import (
@@ -296,6 +297,7 @@ class Proxy(EngineClient):
             socket = self.ctx.socket(zmq.constants.PUSH)
             socket.connect(addr)
             to_sockets[addr] = socket
+            logger.info(f"Connected to worker {addr} success")
         return to_sockets
 
     async def _run_encode(
@@ -642,6 +644,38 @@ class Proxy(EngineClient):
                 )
             )
 
+    async def _worker_register_handler(
+        self, worker_register_req: WorkerRegisterRequest
+    ):
+        """Handle worker register request."""
+        address = worker_register_req.address
+        server_type = worker_register_req.server_type
+
+        SERVER_TYPE_TO_SOCKET_MAP = {
+            ServerType.E_INSTANCE: self.to_encode_sockets,
+            ServerType.PD_INSTANCE: self.to_pd_sockets,
+            ServerType.P_INSTANCE: self.to_p_sockets,
+            ServerType.D_INSTANCE: self.to_d_sockets,
+        }
+        if server_type in SERVER_TYPE_TO_SOCKET_MAP:
+            socket_dict = SERVER_TYPE_TO_SOCKET_MAP[server_type]
+            if address not in socket_dict:
+                try:
+                    socket = self.ctx.socket(zmq.constants.PUSH)
+                    socket.connect(address)
+                    socket_dict[address] = socket
+                except zmq.ZMQError as e:
+                    logger.error(
+                        f"Failed to connect to worker {address} with error: {e}"
+                    )
+        else:
+            logger.error(
+                f"_worker_register_handler fail, unknown server type {server_type}"
+            )
+            return
+
+        logger.info(f"Connected to worker {address} success")
+
     async def _run_output_handler(self) -> None:
         """Background task to pull responses and dispatch to request queues.
 
@@ -655,6 +689,7 @@ class Proxy(EngineClient):
         failure_decoder = msgspec.msgpack.Decoder(FailureResponse)
         heartbeat_decoder = msgspec.msgpack.Decoder(HeartbeatResponse)
         metrics_decoder = msgspec.msgpack.Decoder(MetricsResponse)
+        worker_register_decoder = msgspec.msgpack.Decoder(WorkerRegisterRequest)
         try:
             socket = self.ctx.socket(zmq.constants.PULL)
             socket.bind(self.proxy_addr)
@@ -704,6 +739,7 @@ class Proxy(EngineClient):
                     HeartbeatResponse,
                     FailureResponse,
                     MetricsResponse,
+                    WorkerRegisterRequest,
                 ]
                 # TODO: maybe we can have a mapping from resp_type to prefill
                 if resp_type in (
@@ -718,6 +754,9 @@ class Proxy(EngineClient):
                     resp = failure_decoder.decode(payload)
                 elif resp_type == ResponseType.METRICS:
                     resp = metrics_decoder.decode(payload)
+                elif resp_type == RequestType.REGISTER:
+                    resp = worker_register_decoder.decode(payload)
+                    asyncio.create_task(self._worker_register_handler(resp))
                 else:
                     raise RuntimeError(
                         f"Unknown response type from worker: {resp_type.decode()}"
@@ -727,6 +766,7 @@ class Proxy(EngineClient):
                     if resp_type not in (
                         ResponseType.HEARTBEAT,
                         ResponseType.METRICS,
+                        RequestType.REGISTER,
                     ):
                         logger.warning(
                             "Request %s may have been aborted, ignore response.",

--- a/lm_service/envs.py
+++ b/lm_service/envs.py
@@ -35,11 +35,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "RandomRouter",
         ["RandomRouter", "RoundRobinRouter", "LeastInFlightRouter"],
     ),
-    "LM_SERVICE_REDIS_IP": lambda: os.getenv(
-        "LM_SERVICE_REDIS_IP", "localhost"
-    ),
-    "LM_SERVICE_REDIS_PORT": lambda: int(
-        os.getenv("LM_SERVICE_REDIS_PORT", "6379")
+    "LM_SERVICE_REDIS_ADDRESS": lambda: os.getenv(
+        "LM_SERVICE_REDIS_ADDRESS", None
     ),
     "LM_SERVICE_REDIS_DB": lambda: int(os.getenv("LM_SERVICE_REDIS_DB", "0")),
     "LM_SERVICE_REDIS_PASSWORD": lambda: os.getenv(
@@ -53,6 +50,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "LM_SERVICE_REDIS_KEY_TTL": lambda: int(
         os.getenv("LM_SERVICE_REDIS_KEY_TTL", "600")
+    ),
+    "LM_SERVICE_SOCKET_TIMEOUT": lambda: int(
+        os.getenv("LM_SERVICE_SOCKET_TIMEOUT", "60")
     ),
     "LM_SERVICE_RPC_PORT": lambda: os.getenv("LM_SERVICE_RPC_PORT", None),
     "LM_SERVICE_METASTORE_CLIENT": lambda: os.getenv(

--- a/lm_service/metastore_client/metastore_client_config.py
+++ b/lm_service/metastore_client/metastore_client_config.py
@@ -44,20 +44,11 @@ class MetastoreClientConfig:
     """
     The type of the metastore service to use.
     """
-    # Host address of the metastore service
-    metastore_host: Optional[str] = None
-
-    # Port number of the metastore service
-    metastore_port: Optional[int] = None
-
-    # Password for authenticating with the metastore service
-    metastore_password: str = ""
+    # address of the metastore service
+    metastore_address: Optional[str] = None
 
     # Prefix to use for all keys stored in the metastore
     metastore_key_prefix: str = "lm_service"
-
-    # Database index to use in the metastore
-    metastore_db: int = 0
 
     # Whether to use SSL for the connection
     metastore_ssl: bool = False
@@ -70,6 +61,9 @@ class MetastoreClientConfig:
 
     # Path to the SSL CA certificate file (if SSL is enabled)
     metastore_ssl_cafile: Optional[str] = None
+
+    # Timeout in seconds for socket operations
+    metastore_socket_timeout: int = 60
 
 
 def json_to_metastore_config(

--- a/lm_service/protocol/protocol.py
+++ b/lm_service/protocol/protocol.py
@@ -29,6 +29,7 @@ class RequestType:
     HEARTBEAT = b"\x03"
     METRICS = b"\x04"
     PREFILL = b"\x05"
+    REGISTER = b"\x06"
 
 
 class PDAbortRequest(msgspec.Struct):
@@ -42,6 +43,7 @@ class ResponseType:
     HEARTBEAT = b"\x03"
     METRICS = b"\x04"
     PREFILL = b"\x05"
+    REGISTER = b"\x06"
 
 
 class GenerationResponse(msgspec.Struct):
@@ -102,3 +104,9 @@ class MetricsRequest(msgspec.Struct):
 class MetricsResponse(msgspec.Struct):
     request_id: str
     metrics: Optional[dict[int, dict[str, Union[int, float]]]]
+
+
+class WorkerRegisterRequest(msgspec.Struct):
+    request_id: str
+    server_type: ServerType
+    address: str


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

<!-- Link to any related issues using keywords like "Fixes #123" or "Closes #456" -->

## Changes Made

<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing performed

### Test Coverage
URL连接成功：
INFO 11-23 10:57:54 [config/model.py:1510] Using max model len 128000
INFO 11-23 10:57:54 [factory.py:77] Creating metastore client with name: RedisMetastoreClient and engine_id: RedisMetastoreClient
INFO 11-23 10:57:54 [redis_client.py:182] Redis client initialized with url=redis://redis.example.com:6379/0
INFO 11-23 10:57:54 [redis_client.py:205] Redis clients initialized successfully
INFO 11-23 10:57:54 [redis_client.py:113] Node tcp://7.242.102.181:60135 registered to Redis key lm_service_5
INFO 11-23 10:58:17 [redis_client.py:127] Deploy form is E-PD: False
INFO 11-23 10:58:17 [redis_client.py:469] Establishing ZMQ connection to tcp://7.242.102.181:39000
INFO 11-23 10:58:17 [redis_client.py:475] Successfully connected to tcp://7.242.102.181:39000
INFO 11-23 10:58:17 [redis_client.py:469] Establishing ZMQ connection to tcp://7.242.102.181:40000
INFO 11-23 10:58:17 [redis_client.py:475] Successfully connected to tcp://7.242.102.181:40000
INFO 11-23 10:58:17 [redis_client.py:469] Establishing ZMQ connection to tcp://7.242.102.181:41001
INFO 11-23 10:58:17 [redis_client.py:475] Successfully connected to tcp://7.242.102.181:41001
INFO 11-23 10:58:17 [redis_client.py:469] Establishing ZMQ connection to tcp://7.242.102.181:41000
INFO 11-23 10:58:17 [redis_client.py:475] Successfully connected to tcp://7.242.102.181:41000
INFO 11-23 10:58:27 [redis_client.py:469] Establishing ZMQ connection to tcp://7.242.102.181:41002
INFO 11-23 10:58:27 [redis_client.py:475] Successfully connected to tcp://7.242.102.181:41002

## Documentation

<!-- Mark the relevant options with an "x" -->

- [ ] Documentation updated (if needed)
- [ ] Code comments added/updated
- [ ] API documentation updated (if applicable)

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed off my commits (DCO)

## Screenshots/Output

<!-- If applicable, add screenshots or command output to help explain your changes -->

## Additional Notes

<!-- Add any additional notes, considerations, or context for reviewers -->

## Reviewer Checklist

<!-- For reviewers to complete -->

- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation updated
- [ ] Performance considerations reviewed
- [ ] Security implications considered
- [ ] Breaking changes documented
