### PR TITLE
【BugFix】Fixing the issue of not being able to find metastore_client

### DIFF
--- a/lm_service/apis/vllm/proxy.py
+++ b/lm_service/apis/vllm/proxy.py
@@ -49,6 +49,9 @@ import lm_service.envs as lm_service_envs
 from lm_service.metastore_client.factory import (
     MetastoreClientFactory,
 )
+from lm_service.metastore_client.metastore_client import (
+    MetastoreClientBase,
+)
 from lm_service.metastore_client.metastore_client_config import (
     MetastoreClientConfig,
     json_to_metastore_config,
@@ -110,6 +113,7 @@ class Proxy(EngineClient):
         self.health_check_interval = health_check_interval
         self.health_threshold = health_threshold
         self.output_handler: Optional[asyncio.Task] = None
+        self.metastore_client: Optional[MetastoreClientBase] = None
         self.router = router
         self.is_pd_merged = True
 
@@ -276,7 +280,9 @@ class Proxy(EngineClient):
         )
         if self.transfer_protocol == "ipc" and os.path.exists(socket_path):
             os.remove(socket_path)
-        self.metastore_client.close()
+
+        if self.metastore_client is not None:
+            self.metastore_client.close()
 
     async def log_metrics(self) -> None:
         if self.is_pd_merged:

--- a/lm_service/metastore_client/redis_client.py
+++ b/lm_service/metastore_client/redis_client.py
@@ -375,6 +375,8 @@ class RedisMetastoreClient(MetastoreClientBase):
                 self.redis_client.close()
                 logger.info("Synchronous Redis connection closed")
 
+            self.ctx.destroy()
+
             # For async client, we should close it in an async context
             # This is just a placeholder; the actual closing should be done in an async method
             if self.async_redis_client:

--- a/lm_service/workers/vllm/disagg_worker.py
+++ b/lm_service/workers/vllm/disagg_worker.py
@@ -148,7 +148,8 @@ class DisaggWorker:
         )
         if self.transfer_protocol == "ipc" and os.path.exists(socket_path):
             os.remove(socket_path)
-        self.metastore_client.close()
+        if self.metastore_client is not None:
+            self.metastore_client.close()
 
     def get_server_type(self) -> ServerType:
         if (


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

<!-- Link to any related issues using keywords like "Fixes #123" or "Closes #456" -->

## Changes Made

<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing
Starting encoder workers...
  Encoder worker 0 starting on device 0, address: [2071:192:168:2::181]:39000, log: /workspace/why00613459/epd_mooncake/llm-service/examples/online_serving/epd/logs/encoder_0.log
Starting prefill/decode workers...
  Prefill/decode worker 0 starting on device 1, address: [2071:192:168:2::181]:40000, log: /workspace/why00613459/epd_mooncake/llm-service/examples/online_serving/epd/logs/prefill_decode_0.log
All workers starting. PIDs are stored in /workspace/why00613459/epd_mooncake/llm-service/examples/online_serving/epd/pid.txt.
INFO 11-26 19:44:09 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 11-26 19:44:09 [__init__.py:38] - ascend -> vllm_ascend:register
INFO 11-26 19:44:09 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 11-26 19:44:09 [__init__.py:207] Platform plugin ascend is activated
INFO 11-26 19:44:12 [model.py:547] Resolved architecture: Qwen2_5_VLForConditionalGeneration
`torch_dtype` is deprecated! Use `dtype` instead!
INFO 11-26 19:44:12 [model.py:1510] Using max model len 128000
INFO 11-26 19:44:12 [proxy.py:313] Connected to worker tcp://[2071:192:168:2::181]:39000 success
INFO 11-26 19:44:12 [proxy.py:313] Connected to worker tcp://[2071:192:168:2::181]:40000 success
Request(0) generated_text: The
Request(0) generated_text: The text
Request(1) generated_text: The
Request(2) generated_text: The
Request(3) generated_text: The
Request(4) generated_text: The
Request(5) generated_text: The
Request(6) generated_text: The
Request(7) generated_text: The
Request(8) generated_text: The
Request(9) generated_text: The
Request(0) generated_text: The text i
<!-- Describe how you tested your changes -->

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing performed

### Test Coverage

<!-- If applicable, describe new test coverage -->

## Documentation

<!-- Mark the relevant options with an "x" -->

- [ ] Documentation updated (if needed)
- [ ] Code comments added/updated
- [ ] API documentation updated (if applicable)

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed off my commits (DCO)

## Screenshots/Output

<!-- If applicable, add screenshots or command output to help explain your changes -->

## Additional Notes

<!-- Add any additional notes, considerations, or context for reviewers -->

## Reviewer Checklist

<!-- For reviewers to complete -->

- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation updated
- [ ] Performance considerations reviewed
- [ ] Security implications considered
- [ ] Breaking changes documented
