### PR TITLE
[Feature] Track and update instance health on successful requests

### DIFF
--- a/lm_service/apis/vllm/proxy.py
+++ b/lm_service/apis/vllm/proxy.py
@@ -492,8 +492,9 @@ class Proxy(EngineClient):
         address = worker_register_req.address
         server_type = worker_register_req.server_type
 
-        if server_type in self.server_to_socket_map:
-            socket_dict = self.server_to_socket_map[server_type]
+        if server_type in self.instance_clusters:
+            cluster = self.instance_clusters[server_type]
+            socket_dict = cluster.sockets
             if address not in socket_dict:
                 try:
                     socket = self.ctx.socket(zmq.constants.PUSH)
@@ -503,7 +504,7 @@ class Proxy(EngineClient):
                         f"Failed to connect to worker {address} with error: {e}"
                     )
                     return
-                cluster_lock = self.instance_clusters[server_type].socket_lock
+                cluster_lock = cluster.socket_lock
                 async with cluster_lock:
                     socket_dict[address] = socket
                     logger.info(f"Connected to worker {address} success")

--- a/lm_service/instance_cluster.py
+++ b/lm_service/instance_cluster.py
@@ -100,6 +100,8 @@ class InstanceCluster:
                     raise response
                 self._record_proxy_to_instance_time(addr, response, start_time)
                 finished = response.finish_reason is not None
+                # mark instance latest successful response time
+                self.service_discovery.update_latest_success(addr)
                 yield response
 
         finally:
@@ -129,6 +131,9 @@ class InstanceCluster:
             self._record_proxy_to_instance_time(addr, response, start_time)
             if isinstance(response, Exception):
                 raise response
+            else:
+                # mark instance latest successful response time
+                self.service_discovery.update_latest_success(addr)
         finally:
             self.stats_monitor.on_request_completed(
                 addr, request_id=request.request_id


### PR DESCRIPTION
Added mark_instance_healthy to InstanceCluster and HealthCheckServiceDiscovery to record healthy timestamps for instances after successful requests. Health check loop now only checks instances that haven't been marked healthy recently, reducing unnecessary health checks and improving efficiency.