### PR TITLE
[BugFix]Supports specifying an address

### DIFF
--- a/lm_service/metastore_client/metastore_client.py
+++ b/lm_service/metastore_client/metastore_client.py
@@ -17,7 +17,7 @@ class MetastoreClientBase(ABC):
         self,
         metastore_client_config: Optional[MetastoreClientConfig] = None,
         node_info: str = "",
-        engine_type: Optional[int] = None,
+        server_type: Optional[int] = None,
         to_proxy: Optional[dict[str, zmq.asyncio.Socket]] = None,
         to_encode_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
         to_pd_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
@@ -28,7 +28,7 @@ class MetastoreClientBase(ABC):
     ):
         self.metastore_client_config = metastore_client_config
         self.node_info = node_info
-        self.engine_type = engine_type
+        self.server_type = server_type
         self.to_encode_sockets: dict[str, zmq.asyncio.Socket] = (
             to_encode_sockets if to_encode_sockets is not None else {}
         )
@@ -44,6 +44,12 @@ class MetastoreClientBase(ABC):
         self.to_d_sockets: dict[str, zmq.asyncio.Socket] = (
             to_d_sockets if to_d_sockets is not None else {}
         )
+
+    def launch_proxy_task(self):
+        """
+        Launch proxy task to report node info and update socket.
+        """
+        pass
 
     def close(self):
         """

--- a/lm_service/workers/vllm/disagg_worker.py
+++ b/lm_service/workers/vllm/disagg_worker.py
@@ -77,13 +77,14 @@ class DisaggWorker:
             config: MetastoreClientConfig = json_to_metastore_config(
                 metastore_client_config
             )
-            worker_ip = lm_service_envs.LM_SERVICE_HOST_IP or get_ip()
-            worker_port = (
-                int(lm_service_envs.LM_SERVICE_RPC_PORT)
-                if lm_service_envs.LM_SERVICE_RPC_PORT
-                else get_open_port()
-            )
-            address = f"{worker_ip}:{worker_port}"
+            if address is None:
+                worker_ip = lm_service_envs.LM_SERVICE_HOST_IP or get_ip()
+                worker_port = (
+                    int(lm_service_envs.LM_SERVICE_RPC_PORT)
+                    if lm_service_envs.LM_SERVICE_RPC_PORT
+                    else get_open_port()
+                )
+                address = f"{worker_ip}:{worker_port}"
             self.worker_addr = f"{self.transfer_protocol}://{address}"
             self.ctx = zmq.asyncio.Context()
             if is_addr_ipv6(address) and self.transfer_protocol == "tcp":
@@ -93,7 +94,7 @@ class DisaggWorker:
             self.metastore_client = (
                 MetastoreClientFactory.create_metastore_client(
                     config=config,
-                    engine_type=self.server_type.value,
+                    server_type=self.server_type.value,
                     node_info=self.worker_addr,
                     to_proxy=self.to_proxy,
                 )


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description
1. Supports specifying an address
2. Redis supports lazy startup.
https://github.com/JiusiServe/vllm/issues/167
<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

<!-- Link to any related issues using keywords like "Fixes #123" or "Closes #456" -->

## Changes Made

<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->
推理正常
DEBUG 12-06 18:00:42 [model_executor/models/registry.py:498] Loaded model info for class vllm.model_executor.models.qwen2_5_vl.Qwen2_5_VLForConditionalGeneration from cache
DEBUG 12-06 18:00:42 [logging_utils/log_time.py:27] Registry inspect model class: Elapsed time 0.0007552 secs
INFO 12-06 18:00:42 [config/model.py:547] Resolved architecture: Qwen2_5_VLForConditionalGeneration
`torch_dtype` is deprecated! Use `dtype` instead!
INFO 12-06 18:00:42 [config/model.py:1510] Using max model len 128000
INFO 12-06 18:00:42 [proxy.py:309] Connected to worker tcp://[2071:192:168:2::181]:40000 success
INFO 12-06 18:00:42 [proxy.py:309] Connected to worker tcp://[2071:192:168:2::181]:39000 success
INFO 12-06 18:00:56 [proxy.py:503] Connected to worker tcp://[2071:192:168:2::181]:39000 success
INFO 12-06 18:01:00 [proxy.py:503] Connected to worker tcp://[2071:192:168:2::181]:40000 success
Request(0) generated_text: The
Request(0) generated_text: The text
Request(1) generated_text: The
Request(2) generated_text: The
Request(3) generated_text: The
Request(4) generated_text: The
Request(5) generated_text: The
Request(6) generated_text: The
Request(7) generated_text: The
Request(8) generated_text: The
Request(9) generated_text: The
Request(0) generated_text: The text in
Request(1) generated_text: The text
Request(2) generated_text: The text
Request(3) generated_text: The text

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing performed

### Test Coverage

<!-- If applicable, describe new test coverage -->

## Documentation

<!-- Mark the relevant options with an "x" -->

- [ ] Documentation updated (if needed)
- [ ] Code comments added/updated
- [ ] API documentation updated (if applicable)

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed off my commits (DCO)

## Screenshots/Output

<!-- If applicable, add screenshots or command output to help explain your changes -->

## Additional Notes

<!-- Add any additional notes, considerations, or context for reviewers -->

## Reviewer Checklist

<!-- For reviewers to complete -->

- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation updated
- [ ] Performance considerations reviewed
- [ ] Security implications considered
- [ ] Breaking changes documented
