### PR TITLE
[Refactor] Remove duplicate imports in service_discovery.py

### DIFF
--- a/lm_service/service_discovery.py
+++ b/lm_service/service_discovery.py
@@ -9,9 +9,6 @@ from abc import ABC, abstractmethod
 import zmq
 import zmq.asyncio
 
-import zmq
-import zmq.asyncio
-
 from lm_service.protocol.protocol import ServerType
 from lm_service.logger_utils import init_logger
 


### PR DESCRIPTION
This pull request makes a minor cleanup to the `lm_service/service_discovery.py` file by removing duplicate import statements for `zmq` and `zmq.asyncio`. This helps keep the codebase tidy and avoids unnecessary redundancy.