### PR TITLE
[refactor] Remove pd_addr_list, to_pd_sockets, unify the PD and D instances

### DIFF
--- a/lm_service/envs.py
+++ b/lm_service/envs.py
@@ -16,6 +16,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "TRANSFER_PROTOCOL": env_with_choices(
         "TRANSFER_PROTOCOL", None, ["tcp", "ipc"]
     ),
+    "LM_SERVICE_E_INSTANCE_ROUTER": env_with_choices(
+        "LM_SERVICE_E_INSTANCE_ROUTER",
+        "RandomRouter",
+        ["RandomRouter", "RoundRobinRouter", "LeastInFlightRouter"],
+    ),
     "LM_SERVICE_P_INSTANCE_ROUTER": env_with_choices(
         "LM_SERVICE_P_INSTANCE_ROUTER",
         "RandomRouter",
@@ -28,11 +33,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "LM_SERVICE_PD_INSTANCE_ROUTER": env_with_choices(
         "LM_SERVICE_PD_INSTANCE_ROUTER",
-        "RandomRouter",
-        ["RandomRouter", "RoundRobinRouter", "LeastInFlightRouter"],
-    ),
-    "LM_SERVICE_E_INSTANCE_ROUTER": env_with_choices(
-        "LM_SERVICE_E_INSTANCE_ROUTER",
         "RandomRouter",
         ["RandomRouter", "RoundRobinRouter", "LeastInFlightRouter"],
     ),

--- a/lm_service/instance_cluster.py
+++ b/lm_service/instance_cluster.py
@@ -21,18 +21,22 @@ SERVER_PARAMS_MAP = {
     ServerType.E_INSTANCE: {
         "addr_list_name": "encode_addr_list",
         "run_request_type": RequestType.ENCODE,
+        "socket_list_name": "to_e_sockets",
     },
     ServerType.P_INSTANCE: {
         "addr_list_name": "p_addr_list",
         "run_request_type": RequestType.PREFILL,
+        "socket_list_name": "to_p_sockets",
     },
     ServerType.D_INSTANCE: {
         "addr_list_name": "d_addr_list",
         "run_request_type": RequestType.GENERATION,
+        "socket_list_name": "to_d_sockets",
     },
     ServerType.PD_INSTANCE: {
-        "addr_list_name": "pd_addr_list",
+        "addr_list_name": "d_addr_list",
         "run_request_type": RequestType.GENERATION,
+        "socket_list_name": "to_d_sockets",
     },
 }
 

--- a/lm_service/metastore_client/metastore_client.py
+++ b/lm_service/metastore_client/metastore_client.py
@@ -19,8 +19,7 @@ class MetastoreClientBase(ABC):
         node_info: str = "",
         server_type: Optional[int] = None,
         to_proxy: Optional[dict[str, zmq.asyncio.Socket]] = None,
-        to_encode_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
-        to_pd_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
+        to_e_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
         to_p_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
         to_d_sockets: Optional[dict[str, zmq.asyncio.Socket]] = None,
         *args,
@@ -29,20 +28,17 @@ class MetastoreClientBase(ABC):
         self.metastore_client_config = metastore_client_config
         self.node_info = node_info
         self.server_type = server_type
-        self.to_encode_sockets: dict[str, zmq.asyncio.Socket] = (
-            to_encode_sockets if to_encode_sockets is not None else {}
-        )
-        self.to_pd_sockets: dict[str, zmq.asyncio.Socket] = (
-            to_pd_sockets if to_pd_sockets is not None else {}
-        )
-        self.to_proxy: dict[str, zmq.asyncio.Socket] = (
-            to_proxy if to_proxy is not None else {}
+        self.to_e_sockets: dict[str, zmq.asyncio.Socket] = (
+            to_e_sockets if to_e_sockets is not None else {}
         )
         self.to_p_sockets: dict[str, zmq.asyncio.Socket] = (
             to_p_sockets if to_p_sockets is not None else {}
         )
         self.to_d_sockets: dict[str, zmq.asyncio.Socket] = (
             to_d_sockets if to_d_sockets is not None else {}
+        )
+        self.to_proxy: dict[str, zmq.asyncio.Socket] = (
+            to_proxy if to_proxy is not None else {}
         )
 
     def launch_proxy_task(self):

--- a/lm_service/workers/vllm/disagg_worker.py
+++ b/lm_service/workers/vllm/disagg_worker.py
@@ -152,22 +152,24 @@ class DisaggWorker:
             self.metastore_client.close()
 
     def get_server_type(self) -> ServerType:
-        if (
-            self.ec_transfer_config
-            and self.ec_transfer_config.ec_role == "ec_producer"
-        ):
-            return ServerType.E_INSTANCE
-        elif self.kv_transfer_config:
+        # E - encode cache producer
+        # P - encode cache consumer & kv cache producer
+        # D - kv cache consumer
+        # PD - ec consumer
+
+        if self.kv_transfer_config:
             if self.kv_transfer_config.kv_role == "kv_producer":
                 return ServerType.P_INSTANCE
-            return ServerType.D_INSTANCE
-        elif (
-            self.ec_transfer_config
-            and self.ec_transfer_config.ec_role == "ec_consumer"
-        ):
-            return ServerType.PD_INSTANCE
-        else:
-            return ServerType.PROXY
+            elif self.kv_transfer_config.kv_role == "kv_consumer":
+                return ServerType.D_INSTANCE
+
+        if self.ec_transfer_config:
+            if self.ec_transfer_config.ec_role == "ec_producer":
+                return ServerType.E_INSTANCE
+            elif self.ec_transfer_config.ec_role == "ec_consumer":
+                return ServerType.PD_INSTANCE
+
+        return ServerType.PROXY
 
     async def _send_worker_register_request(
         self, socket_list: list[zmq.asyncio.Socket]


### PR DESCRIPTION
This pull request refactors and simplifies the handling of cluster initialization and socket management in the vLLM proxy and metastore client code. The main focus is to unify the logic for handling PD and D instances, clarify naming conventions for socket dictionaries, and streamline the initialization process for different deployment forms (E-PD vs. E-P-D). Additionally, there are improvements to environment variable handling and request processing.

**Key changes include:**

### Cluster Initialization and Socket Management

- Refactored cluster initialization in `proxy.py` to treat PD and D instances equivalently, simplifying logic and reducing duplication. Added `_init_cluster_with_addr_list` and `_init_cluster_with_metastore` methods for clearer separation of initialization paths. [[1]](diffhunk://#diff-b2e7de586a357f92479d402e20b988a3e44a862e91952fab055b4e8d0622b121L131-R182) [[2]](diffhunk://#diff-b2e7de586a357f92479d402e20b988a3e44a862e91952fab055b4e8d0622b121L159-L236)
- Standardized socket dictionary names across codebase: replaced `to_encode_sockets`/`to_pd_sockets` with `to_e_sockets`/`to_d_sockets` for consistency. Updated all relevant method signatures, property names, and usages in both metastore and redis client classes. [[1]](diffhunk://#diff-029138e0888ae6477d85f46e0975d4903f62c1aa5a4e5e7a27a9149bbbe69f45L22-R22) [[2]](diffhunk://#diff-029138e0888ae6477d85f46e0975d4903f62c1aa5a4e5e7a27a9149bbbe69f45L32-R42) [[3]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL37-R37) [[4]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL52-R61) [[5]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL495-R504) [[6]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL532-R535)
- Updated `SERVER_PARAMS_MAP` in `instance_cluster.py` to use new socket dictionary names and align PD instance handling with D instance logic.

### Deployment Form and Routing Logic

- Improved deployment form detection in the redis metastore client, with clearer distinction between E-PD and E-P-D forms and correct socket updates for each. The property for deployment form is now consistently named `is_pd_merged`. [[1]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL102-R99) [[2]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL158-R155) [[3]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL183-R181) [[4]](diffhunk://#diff-86a8d7783483ba8e0b4eaf1dd1efe0bef52111ba4819dd346867e210f0a8058aL204-R220)
- Simplified request processing in the proxy: always encodes multimodal data first, conditionally performs prefill, and then decodes using the appropriate instance type based on deployment form.

### Environment Variable Handling

- Fixed the declaration and ordering of environment variables in `envs.py`, ensuring `LM_SERVICE_E_INSTANCE_ROUTER` is correctly defined and defaults are set properly. [[1]](diffhunk://#diff-36c628775484655b2623ae2a5bded1339f02a511b8558141587d1a8df8f9e130R19-R23) [[2]](diffhunk://#diff-36c628775484655b2623ae2a5bded1339f02a511b8558141587d1a8df8f9e130L34-L38)

### Metrics and Miscellaneous

- Adjusted metrics collection logic to only calculate `proxy_ttft_avg` for D instances, matching the new unified logic.
- Added input validation and comments to clarify intent in initialization code.

These changes make the codebase more maintainable, reduce confusion around instance types, and improve flexibility for different deployment scenarios.