### PR TITLE
[Bugfix] Update kv_connector to MooncakeConnectorStoreV1

### DIFF
--- a/examples/online_serving/epd/disagg_xeypzd_example.sh
+++ b/examples/online_serving/epd/disagg_xeypzd_example.sh
@@ -84,26 +84,20 @@ function start_prefill() {
             }
         }' \
         --kv-transfer-config '{
-            "kv_connector": "MooncakeConnectorV1",
-            "kv_buffer_device": "npu",
+            "kv_connector": "MooncakeConnectorStoreV1",
             "kv_role": "kv_producer",
-            "kv_parallel_size": 1,
-            "kv_port": "20001",
-            "engine_id": "0",
-            "kv_rank": 0,
-            "kv_connector_module_path": "vllm_ascend.distributed.mooncake_connector",
+            "mooncake_rpc_port": "50053",
             "kv_connector_extra_config": {
-                "prefill": {
-                    "dp_size": 1,
-                    "tp_size": 1
-                },
-                "decode": {
-                    "dp_size": 1,
-                    "tp_size": 1
-                }
+                "local_hostname": "localhost",
+                "metadata_server": "http://localhost:8083/metadata",
+                "protocol": "tcp",
+                "device_name": "",
+                "master_server_address": "localhost:50053",
+                "global_segment_size": 30000000000
             }
         }' \
         >"$log_file" 2>&1 &
+    
     echo $! >> "$PID_FILE"
 }
 
@@ -121,23 +115,16 @@ function start_decoder() {
         --max-num-seqs $MAX_NUM_SEQS_DECODER \
         --enforce-eager \
         --kv-transfer-config '{
-            "kv_connector": "MooncakeConnectorV1",
-            "kv_buffer_device": "npu",
+            "kv_connector": "MooncakeConnectorStoreV1",
             "kv_role": "kv_consumer",
-            "kv_parallel_size": 1,
-            "kv_port": "20002",
-            "engine_id": "0",
-            "kv_rank": 0,
-            "kv_connector_module_path": "vllm_ascend.distributed.mooncake_connector",
+            "mooncake_rpc_port": "50053",
             "kv_connector_extra_config": {
-                "prefill": {
-                    "dp_size": 1,
-                    "tp_size": 1
-                },
-                "decode": {
-                    "dp_size": 1,
-                    "tp_size": 1
-                }
+                "local_hostname": "localhost",
+                "metadata_server": "http://localhost:8083/metadata",
+                "protocol": "tcp",
+                "device_name": "",
+                "master_server_address": "localhost:50053",
+                "global_segment_size": 30000000000
             }
         }' \
         >"$log_file" 2>&1 &


### PR DESCRIPTION
This pull request updates the configuration for the key-value (KV) connector used in both the `start_prefill` and `start_decoder` functions in the `disagg_xeypzd_example.sh` script. The changes mainly modernize the connector setup, remove deprecated parameters, and add new connection details to support the `MooncakeConnectorStoreV1` connector.

**KV Connector Configuration Updates:**

* Switched the `kv_connector` from `MooncakeConnectorV1` to `MooncakeConnectorStoreV1` and removed the `kv_buffer_device` parameter in both the `start_prefill` and `start_decoder` functions. [[1]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L87-R100) [[2]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L124-R127)
* Removed several legacy parameters, including `kv_parallel_size`, `kv_port`, `engine_id`, `kv_rank`, and `kv_connector_module_path`. [[1]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L87-R100) [[2]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L124-R127)
* Added new parameters: `mooncake_rpc_port`, and expanded the `kv_connector_extra_config` with fields such as `local_hostname`, `metadata_server`, `protocol`, `device_name`, `master_server_address`, and `global_segment_size`. [[1]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L87-R100) [[2]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L124-R127)
* Removed the nested `prefill` and `decode` configuration blocks for `dp_size` and `tp_size`. [[1]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L87-R100) [[2]](diffhunk://#diff-7bc5515893fb57646ebe2cca872d873c78dedc57cb093993d544933235d27664L124-R127)