### PR TITLE
[bugfix] Add kv_transfer_params to prefill and generation requests

### DIFF
--- a/lm_service/apis/vllm/proxy.py
+++ b/lm_service/apis/vllm/proxy.py
@@ -179,7 +179,9 @@ class Proxy(EngineClient):
         init_params = locals()
 
         for server_type in SERVER_PARAMS_MAP:
-            if self.is_pd_merged and server_type == ServerType.D_INSTANCE:
+            if (self.is_pd_merged and server_type == ServerType.P_INSTANCE) or (
+                not self.is_pd_merged and server_type == ServerType.PD_INSTANCE
+            ):
                 continue
             addr_param_name = str(
                 SERVER_PARAMS_MAP[server_type]["addr_list_name"]
@@ -224,7 +226,9 @@ class Proxy(EngineClient):
         self.is_pd_merged = self.metastore_client.is_pd_merged
         init_params = locals()
         for server_type in SERVER_PARAMS_MAP:
-            if self.is_pd_merged and server_type == ServerType.P_INSTANCE:
+            if (self.is_pd_merged and server_type == ServerType.P_INSTANCE) or (
+                not self.is_pd_merged and server_type == ServerType.PD_INSTANCE
+            ):
                 continue
             sockets = init_params[
                 SERVER_PARAMS_MAP[server_type]["socket_list_name"]
@@ -320,7 +324,8 @@ class Proxy(EngineClient):
         q: asyncio.Queue[Union[Exception, GenerationResponse]],
     ):
         cluster = self.instance_clusters[server_type]
-        await cluster.process_request(request, q)
+        response = await cluster.process_request(request, q)
+        return response
 
     async def _process_request_streaming_response(
         self,
@@ -424,7 +429,13 @@ class Proxy(EngineClient):
 
             # Step 2 : Maybe Prefill
             if not self.is_pd_merged:
-                await self._process_request(ServerType.P_INSTANCE, request, q)
+                response = await self._process_request(
+                    ServerType.P_INSTANCE, request, q
+                )
+                kv_transfer_params = response.kv_transfer_params
+                request.sampling_params.extra_args["kv_transfer_params"] = (
+                    kv_transfer_params
+                )
 
             # Step 3 : Decode
             decode_server_type = (

--- a/lm_service/instance_cluster.py
+++ b/lm_service/instance_cluster.py
@@ -71,6 +71,20 @@ class InstanceCluster:
 
         # encode payload
         try:
+            if self.server_type == ServerType.P_INSTANCE:
+                kv_transfer_params = {
+                    "do_remote_decode": True,
+                    "do_remote_prefill": False,
+                    "remote_engine_id": None,
+                    "remote_block_ids": None,
+                    "remote_host": None,
+                    "remote_port": None,
+                }
+                request.sampling_params.extra_args = {}
+                request.sampling_params.extra_args["kv_transfer_params"] = (
+                    kv_transfer_params
+                )
+
             payload = self.encoder.encode(request)
         except Exception as e:
             raise RuntimeError("Failed to serialize GenerationRequest") from e
@@ -138,6 +152,8 @@ class InstanceCluster:
             else:
                 # mark instance latest successful response time
                 self.service_discovery.update_latest_success(addr)
+                return response
+
         finally:
             self.stats_monitor.on_request_completed(
                 addr, request_id=request.request_id

--- a/lm_service/protocol/protocol.py
+++ b/lm_service/protocol/protocol.py
@@ -56,6 +56,7 @@ class GenerationResponse(msgspec.Struct):
     stop_reason: Optional[str] = None
     # TODO: support full protocol.
     logprobs = None
+    kv_transfer_params: Optional[dict[str, Any]] = None
     proxy_to_worker_time_end: Optional[float] = None
 
     @classmethod
@@ -71,6 +72,7 @@ class GenerationResponse(msgspec.Struct):
             prompt_token_ids=request_output.prompt_token_ids,
             finish_reason=out.finish_reason,
             stop_reason=str(out.stop_reason),
+            kv_transfer_params=request_output.kv_transfer_params,
         )
 
 


### PR DESCRIPTION
This pull request updates the `disagg_worker.py` logic to support key-value (KV) transfer parameters for distributed inference requests. Specifically, it ensures that when the worker is configured for KV transfer, both prefill and generation requests include the necessary parameters to enable remote decoding.

Enhancements for distributed inference:

* In the `_handle_request` method of `disagg_worker.py`, added logic to inject `kv_transfer_params` into `sampling_params` for both prefill and generation requests when `kv_transfer_config` is set, enabling remote decode functionality.